### PR TITLE
docs: clarify that remote indexing requires clangd 12+

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -16,8 +16,9 @@ More details on
 **Googlers only** : clangd is installed on `/usr/bin/clangd` by default on
 glinux workstations, you can directly use that instead.
 
-[clangd/releases](https://github.com/clangd/clangd/releases) are
-built with that support for major platforms. You can find out about other
+Remote index support requires **clangd 12** or newer, and is not yet included
+in default builds. [clangd/releases](https://github.com/clangd/clangd/releases)
+are built with that support for major platforms. You can find out about other
 options in [here](https://clangd.llvm.org/remote-index.html#clangd-client).
 
 After acquiring the binary, make sure your LSP client points to it. Details
@@ -137,6 +138,16 @@ V[12:49:24.662] Remote index connection [linux.clangd-index.chromium.org:5900]: 
 Note that to see the verbose logs you need to pass in `-log=verbose` to clangd.
 You can find details about accessing clangd logs in
 https://clangd.llvm.org/troubleshooting.html#gathering-logs.
+
+### Unknown key config warning
+
+If you have the following warning:
+
+> I[00:00:00.000] config warning at /path/to/.config/clangd/config.yaml:5:2:
+> Unknown Index key External
+
+It means your version of clangd is too old or was not built with remote index
+support. See [Getting clangd client](#getting-clangd-client) for more details.
 
 ### Untrusted config warning
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,10 +16,19 @@ More details on
 **Googlers only** : clangd is installed on `/usr/bin/clangd` by default on
 glinux workstations, you can directly use that instead.
 
-Remote index support requires **clangd 12** or newer, and is not yet included
-in default builds. [clangd/releases](https://github.com/clangd/clangd/releases)
-are built with that support for major platforms. You can find out about other
-options in [here](https://clangd.llvm.org/remote-index.html#clangd-client).
+You will need **clangd 12** or newer, [built with remote index support][build].
+This feature is not yet enabled by default, but the [clangd/clangd releases]
+*do* enable it. On clangd 13+, you can verify that by checking for “grpc” in
+the output of `clangd --version`:
+
+[build]: https://clangd.llvm.org/design/remote-index.html#buildingreleases
+[clangd/clangd releases]: https://github.com/clangd/clangd/releases
+
+```
+> clangd --version
+clangd version 13.0.0 (https://github.com/llvm/llvm-project ...)
+Features: linux+grpc
+```
 
 After acquiring the binary, make sure your LSP client points to it. Details
 about this process can be found
@@ -139,7 +148,7 @@ Note that to see the verbose logs you need to pass in `-log=verbose` to clangd.
 You can find details about accessing clangd logs in
 https://clangd.llvm.org/troubleshooting.html#gathering-logs.
 
-### Unknown key config warning
+### Unknown config key warning
 
 If you have the following warning:
 


### PR DESCRIPTION
This patch notes that clangd 12 is required for remote indexing, even though Chromium otherwise supports clangd 11.

I spent a lot of time scratching my head at this, since this was not mentioned in <https://clangd.llvm.org/design/remote-index.html>.

See also <https://crrev.com/c/3412467>.