### PR TITLE
Make use of date as the release tag

### DIFF
--- a/indexer/run.sh
+++ b/indexer/run.sh
@@ -40,10 +40,9 @@ export BUILD_DIR=$(readlink -f out/Default)
 # throughout the indexing pipeline.
 
 DATE=$(date -u +%Y%m%d)
-
 COMMIT=$(git rev-parse --short HEAD)
-
-gh release create $COMMIT --repo clangd/chrome-remote-index \
+RELEASE_NAME="index/${DATE}"
+gh release create $RELEASE_NAME --repo clangd/chrome-remote-index \
   --title="Index at $DATE" \
   --notes="Chromium index artifacts at $COMMIT with project root \`$PWD\`."
 
@@ -72,7 +71,7 @@ index() {
 
   7z a chrome-index-$PLATFORM-$DATE.zip /chrome-$PLATFORM.idx
 
-  gh release upload --repo clangd/chrome-remote-index $COMMIT chrome-index-$PLATFORM-$DATE.zip
+  gh release upload --repo clangd/chrome-remote-index $RELEASE_NAME chrome-index-$PLATFORM-$DATE.zip
 
   # Clean up the artifacts.
   rm -rf $BUILD_DIR /chrome-$PLATFORM.idx chrome-index-$PLATFORM-$DATE.zip


### PR DESCRIPTION
GitHub releases page seems to be sorted on the descending semver ordering of
tags, in the case of commits associated with the releases having the same
creation time.
Since that's the case with index artifacts, by making use of date as release
tags, we somewhat gurantee having a fresh index.
