### PR TITLE
Update indexer image for new build deps

### DIFF
--- a/indexer/Dockerfile
+++ b/indexer/Dockerfile
@@ -11,7 +11,7 @@ FROM ubuntu:20.04
 
 # GitHub Authentification token.
 ARG TOKEN
-ARG DEBIAN_FRONTEND=noninteractive
+ENV DEBIAN_FRONTEND=noninteractive
 ENV GITHUB_TOKEN=$TOKEN
 
 RUN if [ -z "$GITHUB_TOKEN" ]; then \
@@ -46,6 +46,7 @@ COPY prepare.sh prepare.sh
 RUN chmod +x /prepare.sh
 
 RUN echo "GITHUB_TOKEN=$GITHUB_TOKEN" >> /etc/environment
+RUN echo "DEBIAN_FRONTEND=noninteractive" >> /etc/environment
 
 COPY entry_point.sh entry_point.sh
 RUN chmod +x /entry_point.sh

--- a/indexer/prepare.sh
+++ b/indexer/prepare.sh
@@ -37,10 +37,7 @@ cd src
 
 gclient sync --no-history
 
-# Remove snapcraft from dependency list: installing it is not feasible inside
-# Docker.
-sed -i '/if package_exists("snapcraft"):/,/packages.append("snapcraft")/d' ./build/install-build-deps.py
-build/install-build-deps-android.sh || true
+build/install-build-deps.py || true
 
 gclient runhooks
 

--- a/indexer/run.sh
+++ b/indexer/run.sh
@@ -76,10 +76,7 @@ index() {
 
 # --- Linux ---
 
-# Remove snapcraft from dependency list: installing it is not feasible inside
-# Docker.
-sed -i '/if package_exists("snapcraft"):/,/packages.append("snapcraft")/d' ./build/install-build-deps.py
-./build/install-build-deps.sh || true
+./build/install-build-deps.py || true
 
 index linux 'target_os="linux"' || true
 
@@ -88,8 +85,6 @@ index linux 'target_os="linux"' || true
 index chromeos 'target_os="chromeos"' || true
 
 # --- Android ---
-
-build/install-build-deps-android.sh || true
 
 index android 'target_os="android"' || true
 


### PR DESCRIPTION
install-build-deps script in chromium repo has changed. it now installs some
packages that require user input for configuration. there's also no android
specific installation script, instead it's installed with the main script by
default.

These changes ensures we propagate relevant env variables into container and use
the new script. Dep on snapcraft is also no longer needed.
